### PR TITLE
fix(Rune): Rune effect loss when placed soulbound/fireproof blocks are broken

### DIFF
--- a/src/main/java/io/github/pylonmc/pylon/Pylon.java
+++ b/src/main/java/io/github/pylonmc/pylon/Pylon.java
@@ -7,6 +7,7 @@ import io.github.pylonmc.pylon.content.machines.fluid.Sprinkler;
 import io.github.pylonmc.pylon.content.machines.simple.Grindstone;
 import io.github.pylonmc.pylon.content.machines.smelting.Bloomery;
 import io.github.pylonmc.pylon.content.talismans.*;
+import io.github.pylonmc.pylon.content.tools.FireproofRune;
 import io.github.pylonmc.pylon.content.tools.SoulboundRune;
 import io.github.pylonmc.pylon.content.tools.base.Rune;
 import io.github.pylonmc.rebar.addon.RebarAddon;
@@ -60,6 +61,7 @@ public class Pylon extends JavaPlugin implements RebarAddon {
         pm.registerEvents(new Immobilizer.FreezeListener(), this);
         pm.registerEvents(new Rune.RuneListener(), this);
         pm.registerEvents(new SoulboundRune.SoulboundRuneListener(), this);
+        pm.registerEvents(new FireproofRune.FireproofRuneListener(), this);
         pm.registerEvents(new Bloomery.CreationListener(), this);
         pm.registerEvents(new Grindstone.PlaceListener(), this);
         pm.registerEvents(new FarmingTalisman.FarmingTalismanListener(), this);

--- a/src/main/java/io/github/pylonmc/pylon/content/tools/FireproofRune.java
+++ b/src/main/java/io/github/pylonmc/pylon/content/tools/FireproofRune.java
@@ -3,13 +3,14 @@ package io.github.pylonmc.pylon.content.tools;
 import com.destroystokyo.paper.ParticleBuilder;
 import io.github.pylonmc.pylon.content.tools.base.Rune;
 import io.github.pylonmc.rebar.block.RebarBlock;
-import io.github.pylonmc.rebar.block.context.BlockBreakContext.PlayerBreak;
 import io.github.pylonmc.rebar.config.adapter.ConfigAdapter;
 import io.github.pylonmc.rebar.datatypes.RebarSerializers;
 import io.github.pylonmc.rebar.event.RebarBlockBreakEvent;
 import io.github.pylonmc.rebar.event.RebarBlockDeserializeEvent;
 import io.github.pylonmc.rebar.event.RebarBlockPlaceEvent;
 import io.github.pylonmc.rebar.event.RebarBlockSerializeEvent;
+import io.github.pylonmc.rebar.event.RebarBlockUnloadEvent;
+import io.github.pylonmc.rebar.item.RebarItemSchema;
 import io.github.pylonmc.rebar.item.builder.ItemStackBuilder;
 import io.github.pylonmc.rebar.util.RandomizedSound;
 import io.papermc.paper.datacomponent.DataComponentTypes;
@@ -19,7 +20,7 @@ import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.keys.tags.DamageTypeTagKeys;
 import io.papermc.paper.registry.tag.Tag;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.translation.GlobalTranslator;
+import net.kyori.adventure.text.format.TextDecoration;
 
 import static io.github.pylonmc.pylon.util.PylonUtils.pylonKey;
 
@@ -102,7 +103,7 @@ public class FireproofRune extends Rune {
         ItemStack handle = ItemStackBuilder.of(target.asQuantity(consume)) // Already cloned in `asQuantity`
                 .set(DataComponentTypes.DAMAGE_RESISTANT, DamageResistant.damageResistant(IS_FIRE_TAG))
                 .editPdc(pdc -> pdc.set(FIREPROOF_KEY, RebarSerializers.BOOLEAN, true))
-                .lore(GlobalTranslator.render(TOOLTIP, player.locale()))
+                .lore(TOOLTIP.decoration(TextDecoration.ITALIC, true))
                 .build();
 
         // (N)Either left runes or targets
@@ -139,31 +140,39 @@ public class FireproofRune extends Rune {
     }
 
     public static class FireproofRuneListener implements Listener {
-        private List<RebarBlock> fireproof_blocks = new ArrayList<>();
+        private final List<RebarBlock> fireproofBlocks = new ArrayList<>();
 
         @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
         public void onBlockPlace(RebarBlockPlaceEvent event) {
-            ItemStack itemStack = event.getContext().getItem().asOne();
+            ItemStack itemStack = event.getContext().getItem();
+            if (itemStack == null || itemStack.isEmpty()) return; //for safety
             RebarBlock block = event.getRebarBlock();
             if (itemStack.getPersistentDataContainer().has(FIREPROOF_KEY)) {
-                fireproof_blocks.add(block);
+                fireproofBlocks.add(block);
             }
         }
 
         @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
         public void onBlockBreak(@NotNull RebarBlockBreakEvent event) {
             RebarBlock block = event.getRebarBlock();
-            if (!(event.getContext() instanceof PlayerBreak playerBreak)) return;
-            Player player = playerBreak.event().getPlayer();
-            for (ItemStack itemStack : event.getDrops()) {
-                List<Component> lore = new ArrayList<>(itemStack.lore());
-                if (fireproof_blocks.contains(block)) {
-                    fireproof_blocks.remove(block);
-                    lore.add(GlobalTranslator.render(Component.translatable("pylon.message.fireproof_result.tooltip"), player.locale()));
+            if (fireproofBlocks.contains(block)) {
+                fireproofBlocks.remove(block);
+                for (ItemStack itemStack : event.getDrops()) {
+                    RebarItemSchema dropSchema = RebarItemSchema.fromStack(itemStack);  
+                    if (dropSchema == null) continue; //use schema to make sure as same as itself
+
+                    NamespacedKey blockItemKey = block.getSchema().getKey();
+                    if (blockItemKey == null || !dropSchema.getKey().equals(blockItemKey)) continue;
+
+                    List<Component> lore = new ArrayList<>(itemStack.lore());
+                    lore.add(Component.translatable("pylon.message.fireproof_result.tooltip")
+                        .decoration(TextDecoration.ITALIC, true)); //make sure lore is italic
+                    itemStack.lore(lore);
+
                     itemStack.setData(DataComponentTypes.DAMAGE_RESISTANT, DamageResistant.damageResistant(FireproofRune.IS_FIRE_TAG));
                     itemStack.editPersistentDataContainer(pdc -> pdc.set(FIREPROOF_KEY, RebarSerializers.BOOLEAN, true));
+                    break;
                 }
-                itemStack.lore(lore);
             }
         }
 
@@ -171,7 +180,7 @@ public class FireproofRune extends Rune {
         public void onSerialize(@NotNull RebarBlockSerializeEvent event) {
             RebarBlock block = event.getRebarBlock();
             PersistentDataContainer pdc = event.getPdc();
-            if (fireproof_blocks.contains(block)) {
+            if (fireproofBlocks.contains(block)) {
                 pdc.set(FIREPROOF_KEY, RebarSerializers.BOOLEAN, true);
             }
         }
@@ -180,7 +189,12 @@ public class FireproofRune extends Rune {
         public void onDeserialize(@NotNull RebarBlockDeserializeEvent event) {
             RebarBlock block = event.getRebarBlock();
             PersistentDataContainer pdc = event.getPdc();
-            if (pdc.has(FIREPROOF_KEY) && !fireproof_blocks.contains(block)) fireproof_blocks.add(block);
+            if (pdc.has(FIREPROOF_KEY) && !fireproofBlocks.contains(block)) fireproofBlocks.add(block);
+        }
+
+        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+        public void onBlockUnload(@NotNull RebarBlockUnloadEvent event) { //add unload event
+            fireproofBlocks.remove(event.getRebarBlock());
         }
     }
 }

--- a/src/main/java/io/github/pylonmc/pylon/content/tools/FireproofRune.java
+++ b/src/main/java/io/github/pylonmc/pylon/content/tools/FireproofRune.java
@@ -59,14 +59,14 @@ public class FireproofRune extends Rune {
     }
 
     /**
-     * Checks if the target is already fireproof.
+     * Checks if the target is already give fireproof by fireproof_rune.
      *
      * @param target The item to handle, amount may be > 1
      * @return true if is fireproof, false otherwise
      */
     public static boolean isFireproof(@NotNull ItemStack target) {
         return target.getPersistentDataContainer()
-            .getOrDefault(FIREPROOF_KEY, RebarSerializers.BOOLEAN, false);
+                .getOrDefault(FIREPROOF_KEY, RebarSerializers.BOOLEAN, false);
     }
     /**
      * Fixes #156 - Fireproof rune can be applied multiple times
@@ -80,10 +80,10 @@ public class FireproofRune extends Rune {
      */
     @Override
     public boolean isApplicableToTarget(@NotNull PlayerDropItemEvent event, @NotNull ItemStack rune, @NotNull ItemStack target) {
-        // DamageResistant data = target.getData(DataComponentTypes.DAMAGE_RESISTANT);
-        // if (data == null) return true;
-        // return !data.types().equals(IS_FIRE_TAG);
-        return !isFireproof(target);
+        if (isFireproof(target)) return false;
+        DamageResistant data = target.getData(DataComponentTypes.DAMAGE_RESISTANT);
+        if (data == null) return true;
+        return !data.types().equals(IS_FIRE_TAG);
     }
 
     /**

--- a/src/main/java/io/github/pylonmc/pylon/content/tools/FireproofRune.java
+++ b/src/main/java/io/github/pylonmc/pylon/content/tools/FireproofRune.java
@@ -2,7 +2,14 @@ package io.github.pylonmc.pylon.content.tools;
 
 import com.destroystokyo.paper.ParticleBuilder;
 import io.github.pylonmc.pylon.content.tools.base.Rune;
+import io.github.pylonmc.rebar.block.RebarBlock;
+import io.github.pylonmc.rebar.block.context.BlockBreakContext.PlayerBreak;
 import io.github.pylonmc.rebar.config.adapter.ConfigAdapter;
+import io.github.pylonmc.rebar.datatypes.RebarSerializers;
+import io.github.pylonmc.rebar.event.RebarBlockBreakEvent;
+import io.github.pylonmc.rebar.event.RebarBlockDeserializeEvent;
+import io.github.pylonmc.rebar.event.RebarBlockPlaceEvent;
+import io.github.pylonmc.rebar.event.RebarBlockSerializeEvent;
 import io.github.pylonmc.rebar.item.builder.ItemStackBuilder;
 import io.github.pylonmc.rebar.util.RandomizedSound;
 import io.papermc.paper.datacomponent.DataComponentTypes;
@@ -10,17 +17,27 @@ import io.papermc.paper.datacomponent.item.DamageResistant;
 import io.papermc.paper.registry.RegistryAccess;
 import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.keys.tags.DamageTypeTagKeys;
-import io.papermc.paper.registry.set.RegistrySet;
 import io.papermc.paper.registry.tag.Tag;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.translation.GlobalTranslator;
+
+import static io.github.pylonmc.pylon.util.PylonUtils.pylonKey;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
 import org.bukkit.Particle;
 import org.bukkit.World;
 import org.bukkit.damage.DamageType;
 import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.persistence.PersistentDataContainer;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -33,12 +50,24 @@ public class FireproofRune extends Rune {
     public static final Component SUCCESS = Component.translatable("pylon.message.fireproof_result.success");
     public static final Component TOOLTIP = Component.translatable("pylon.message.fireproof_result.tooltip");
 
+    public static final NamespacedKey FIREPROOF_KEY = pylonKey("have_fireproof");
+
     private final RandomizedSound applySound = getSettingOrThrow("apply-sound", ConfigAdapter.RANDOMIZED_SOUND);
 
     public FireproofRune(@NotNull ItemStack stack) {
         super(stack);
     }
 
+    /**
+     * Checks if the target is already fireproof.
+     *
+     * @param target The item to handle, amount may be > 1
+     * @return true if is fireproof, false otherwise
+     */
+    public static boolean isFireproof(@NotNull ItemStack target) {
+        return target.getPersistentDataContainer()
+            .getOrDefault(FIREPROOF_KEY, RebarSerializers.BOOLEAN, false);
+    }
     /**
      * Fixes #156 - Fireproof rune can be applied multiple times
      * <p>
@@ -51,9 +80,10 @@ public class FireproofRune extends Rune {
      */
     @Override
     public boolean isApplicableToTarget(@NotNull PlayerDropItemEvent event, @NotNull ItemStack rune, @NotNull ItemStack target) {
-        DamageResistant data = target.getData(DataComponentTypes.DAMAGE_RESISTANT);
-        if (data == null) return true;
-        return !data.types().equals(IS_FIRE_TAG);
+        // DamageResistant data = target.getData(DataComponentTypes.DAMAGE_RESISTANT);
+        // if (data == null) return true;
+        // return !data.types().equals(IS_FIRE_TAG);
+        return !isFireproof(target);
     }
 
     /**
@@ -71,6 +101,7 @@ public class FireproofRune extends Rune {
         Player player = event.getPlayer();
         ItemStack handle = ItemStackBuilder.of(target.asQuantity(consume)) // Already cloned in `asQuantity`
                 .set(DataComponentTypes.DAMAGE_RESISTANT, DamageResistant.damageResistant(IS_FIRE_TAG))
+                .editPdc(pdc -> pdc.set(FIREPROOF_KEY, RebarSerializers.BOOLEAN, true))
                 .lore(GlobalTranslator.render(TOOLTIP, player.locale()))
                 .build();
 
@@ -105,5 +136,51 @@ public class FireproofRune extends Rune {
                 .offset(0, 0, 0)
                 .count(count)
                 .spawn();
+    }
+
+    public static class FireproofRuneListener implements Listener {
+        private List<RebarBlock> fireproof_blocks = new ArrayList<>();
+
+        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+        public void onBlockPlace(RebarBlockPlaceEvent event) {
+            ItemStack itemStack = event.getContext().getItem().asOne();
+            RebarBlock block = event.getRebarBlock();
+            if (itemStack.getPersistentDataContainer().has(FIREPROOF_KEY)) {
+                fireproof_blocks.add(block);
+            }
+        }
+
+        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+        public void onBlockBreak(@NotNull RebarBlockBreakEvent event) {
+            RebarBlock block = event.getRebarBlock();
+            if (!(event.getContext() instanceof PlayerBreak playerBreak)) return;
+            Player player = playerBreak.event().getPlayer();
+            for (ItemStack itemStack : event.getDrops()) {
+                List<Component> lore = new ArrayList<>(itemStack.lore());
+                if (fireproof_blocks.contains(block)) {
+                    fireproof_blocks.remove(block);
+                    lore.add(GlobalTranslator.render(Component.translatable("pylon.message.fireproof_result.tooltip"), player.locale()));
+                    itemStack.setData(DataComponentTypes.DAMAGE_RESISTANT, DamageResistant.damageResistant(FireproofRune.IS_FIRE_TAG));
+                    itemStack.editPersistentDataContainer(pdc -> pdc.set(FIREPROOF_KEY, RebarSerializers.BOOLEAN, true));
+                }
+                itemStack.lore(lore);
+            }
+        }
+
+        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+        public void onSerialize(@NotNull RebarBlockSerializeEvent event) {
+            RebarBlock block = event.getRebarBlock();
+            PersistentDataContainer pdc = event.getPdc();
+            if (fireproof_blocks.contains(block)) {
+                pdc.set(FIREPROOF_KEY, RebarSerializers.BOOLEAN, true);
+            }
+        }
+
+        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+        public void onDeserialize(@NotNull RebarBlockDeserializeEvent event) {
+            RebarBlock block = event.getRebarBlock();
+            PersistentDataContainer pdc = event.getPdc();
+            if (pdc.has(FIREPROOF_KEY) && !fireproof_blocks.contains(block)) fireproof_blocks.add(block);
+        }
     }
 }

--- a/src/main/java/io/github/pylonmc/pylon/content/tools/FireproofRune.java
+++ b/src/main/java/io/github/pylonmc/pylon/content/tools/FireproofRune.java
@@ -20,13 +20,6 @@ import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.registry.keys.tags.DamageTypeTagKeys;
 import io.papermc.paper.registry.tag.Tag;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.TextDecoration;
-
-import static io.github.pylonmc.pylon.util.PylonUtils.pylonKey;
-
-import java.util.ArrayList;
-import java.util.List;
-
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Particle;
@@ -38,8 +31,12 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.persistence.PersistentDataContainer;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.github.pylonmc.pylon.util.PylonUtils.pylonKey;
 
 /**
  * @author balugaq
@@ -60,16 +57,6 @@ public class FireproofRune extends Rune {
     }
 
     /**
-     * Checks if the target is already give fireproof by fireproof_rune.
-     *
-     * @param target The item to handle, amount may be > 1
-     * @return true if is fireproof, false otherwise
-     */
-    public static boolean isFireproof(@NotNull ItemStack target) {
-        return target.getPersistentDataContainer()
-                .getOrDefault(FIREPROOF_KEY, RebarSerializers.BOOLEAN, false);
-    }
-    /**
      * Fixes #156 - Fireproof rune can be applied multiple times
      * <p>
      * Checks if the rune is applicable to the target item.
@@ -81,7 +68,7 @@ public class FireproofRune extends Rune {
      */
     @Override
     public boolean isApplicableToTarget(@NotNull PlayerDropItemEvent event, @NotNull ItemStack rune, @NotNull ItemStack target) {
-        if (isFireproof(target)) return false;
+        if (hasRuneApplied(target)) return false;
         DamageResistant data = target.getData(DataComponentTypes.DAMAGE_RESISTANT);
         if (data == null) return true;
         return !data.types().equals(IS_FIRE_TAG);
@@ -100,11 +87,7 @@ public class FireproofRune extends Rune {
         int consume = Math.min(rune.getAmount(), target.getAmount());
 
         Player player = event.getPlayer();
-        ItemStack handle = ItemStackBuilder.of(target.asQuantity(consume)) // Already cloned in `asQuantity`
-                .set(DataComponentTypes.DAMAGE_RESISTANT, DamageResistant.damageResistant(IS_FIRE_TAG))
-                .editPdc(pdc -> pdc.set(FIREPROOF_KEY, RebarSerializers.BOOLEAN, true))
-                .lore(TOOLTIP.decoration(TextDecoration.ITALIC, true))
-                .build();
+        ItemStack handle = applyRune(target, consume);
 
         // (N)Either left runes or targets
         int leftRunes = rune.getAmount() - consume;
@@ -139,61 +122,75 @@ public class FireproofRune extends Rune {
                 .spawn();
     }
 
+    public static ItemStack applyRune(@NotNull ItemStack itemStack, int amount) {
+        return ItemStackBuilder.of(itemStack.asQuantity(amount))
+                .set(DataComponentTypes.DAMAGE_RESISTANT, DamageResistant.damageResistant(IS_FIRE_TAG))
+                .editPdc(pdc -> pdc.set(FIREPROOF_KEY, RebarSerializers.BOOLEAN, true))
+                .lore(TOOLTIP)
+                .build();
+    }
+
+    /**
+     * Checks if the target already has the fireproof rune applied
+     *
+     * @return true if the fireproof rune has been used on the item, false otherwise
+     */
+    public static boolean hasRuneApplied(@NotNull ItemStack itemStack) {
+        return itemStack.getPersistentDataContainer().getOrDefault(FIREPROOF_KEY, RebarSerializers.BOOLEAN, false);
+    }
+
     public static class FireproofRuneListener implements Listener {
         private final List<RebarBlock> fireproofBlocks = new ArrayList<>();
 
         @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
         public void onBlockPlace(RebarBlockPlaceEvent event) {
             ItemStack itemStack = event.getContext().getItem();
-            if (itemStack == null || itemStack.isEmpty()) return; //for safety
-            RebarBlock block = event.getRebarBlock();
+            if (itemStack == null || itemStack.isEmpty()) {
+                return;
+            }
+
             if (itemStack.getPersistentDataContainer().has(FIREPROOF_KEY)) {
-                fireproofBlocks.add(block);
-            }
-        }
-
-        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-        public void onBlockBreak(@NotNull RebarBlockBreakEvent event) {
-            RebarBlock block = event.getRebarBlock();
-            if (fireproofBlocks.contains(block)) {
-                fireproofBlocks.remove(block);
-                for (ItemStack itemStack : event.getDrops()) {
-                    RebarItemSchema dropSchema = RebarItemSchema.fromStack(itemStack);  
-                    if (dropSchema == null) continue; //use schema to make sure as same as itself
-
-                    NamespacedKey blockItemKey = block.getSchema().getKey();
-                    if (blockItemKey == null || !dropSchema.getKey().equals(blockItemKey)) continue;
-
-                    List<Component> lore = new ArrayList<>(itemStack.lore());
-                    lore.add(Component.translatable("pylon.message.fireproof_result.tooltip")
-                        .decoration(TextDecoration.ITALIC, true)); //make sure lore is italic
-                    itemStack.lore(lore);
-
-                    itemStack.setData(DataComponentTypes.DAMAGE_RESISTANT, DamageResistant.damageResistant(FireproofRune.IS_FIRE_TAG));
-                    itemStack.editPersistentDataContainer(pdc -> pdc.set(FIREPROOF_KEY, RebarSerializers.BOOLEAN, true));
-                    break;
-                }
-            }
-        }
-
-        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-        public void onSerialize(@NotNull RebarBlockSerializeEvent event) {
-            RebarBlock block = event.getRebarBlock();
-            PersistentDataContainer pdc = event.getPdc();
-            if (fireproofBlocks.contains(block)) {
-                pdc.set(FIREPROOF_KEY, RebarSerializers.BOOLEAN, true);
+                fireproofBlocks.add(event.getRebarBlock());
             }
         }
 
         @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
         public void onDeserialize(@NotNull RebarBlockDeserializeEvent event) {
             RebarBlock block = event.getRebarBlock();
-            PersistentDataContainer pdc = event.getPdc();
-            if (pdc.has(FIREPROOF_KEY) && !fireproofBlocks.contains(block)) fireproofBlocks.add(block);
+            if (event.getPdc().has(FIREPROOF_KEY) && !fireproofBlocks.contains(block)) {
+                fireproofBlocks.add(block);
+            }
         }
 
         @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-        public void onBlockUnload(@NotNull RebarBlockUnloadEvent event) { //add unload event
+        public void onSerialize(@NotNull RebarBlockSerializeEvent event) {
+            if (fireproofBlocks.contains(event.getRebarBlock())) {
+                event.getPdc().set(FIREPROOF_KEY, RebarSerializers.BOOLEAN, true);
+            }
+        }
+
+        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+        public void onBlockBreak(@NotNull RebarBlockBreakEvent event) {
+            RebarBlock block = event.getRebarBlock();
+            if (!fireproofBlocks.remove(block)) {
+                return;
+            }
+
+            for (ItemStack itemStack : event.getDrops()) {
+                RebarItemSchema dropSchema = RebarItemSchema.fromStack(itemStack);
+                if (dropSchema == null || !block.getKey().equals(dropSchema.getRebarBlockKey())) {
+                    continue;
+                }
+
+                ItemStack fireproofStack = applyRune(itemStack, 1);
+                itemStack.subtract();
+                event.getDrops().add(fireproofStack);
+                break;
+            }
+        }
+
+        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+        public void onBlockUnload(@NotNull RebarBlockUnloadEvent event) {
             fireproofBlocks.remove(event.getRebarBlock());
         }
     }

--- a/src/main/java/io/github/pylonmc/pylon/content/tools/FireproofRune.java
+++ b/src/main/java/io/github/pylonmc/pylon/content/tools/FireproofRune.java
@@ -2,14 +2,11 @@ package io.github.pylonmc.pylon.content.tools;
 
 import com.destroystokyo.paper.ParticleBuilder;
 import io.github.pylonmc.pylon.content.tools.base.Rune;
+import io.github.pylonmc.rebar.block.BlockStorage;
 import io.github.pylonmc.rebar.block.RebarBlock;
 import io.github.pylonmc.rebar.config.adapter.ConfigAdapter;
 import io.github.pylonmc.rebar.datatypes.RebarSerializers;
 import io.github.pylonmc.rebar.event.RebarBlockBreakEvent;
-import io.github.pylonmc.rebar.event.RebarBlockDeserializeEvent;
-import io.github.pylonmc.rebar.event.RebarBlockPlaceEvent;
-import io.github.pylonmc.rebar.event.RebarBlockSerializeEvent;
-import io.github.pylonmc.rebar.event.RebarBlockUnloadEvent;
 import io.github.pylonmc.rebar.item.RebarItemSchema;
 import io.github.pylonmc.rebar.item.builder.ItemStackBuilder;
 import io.github.pylonmc.rebar.util.RandomizedSound;
@@ -24,17 +21,22 @@ import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Particle;
 import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.ShulkerBox;
 import org.bukkit.damage.DamageType;
+import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockDropItemEvent;
+import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.BlockStateMeta;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
-import java.util.List;
 
 import static io.github.pylonmc.pylon.util.PylonUtils.pylonKey;
 
@@ -140,58 +142,88 @@ public class FireproofRune extends Rune {
     }
 
     public static class FireproofRuneListener implements Listener {
-        private final List<RebarBlock> fireproofBlocks = new ArrayList<>();
-
         @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-        public void onBlockPlace(RebarBlockPlaceEvent event) {
-            ItemStack itemStack = event.getContext().getItem();
+        public void onBlockPlace(BlockPlaceEvent event) { // use chunk pdc
+            ItemStack itemStack = event.getItemInHand();
             if (itemStack == null || itemStack.isEmpty()) {
                 return;
             }
 
-            if (itemStack.getPersistentDataContainer().has(FIREPROOF_KEY)) {
-                fireproofBlocks.add(event.getRebarBlock());
+            Block block = event.getBlock();
+            if (hasRuneApplied(itemStack)) {
+                block.getChunk().getPersistentDataContainer()
+                    .set(getChunkPDC(block.getLocation()), RebarSerializers.ITEM_STACK, itemStack.asOne());
             }
         }
 
         @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-        public void onDeserialize(@NotNull RebarBlockDeserializeEvent event) {
-            RebarBlock block = event.getRebarBlock();
-            if (event.getPdc().has(FIREPROOF_KEY) && !fireproofBlocks.contains(block)) {
-                fireproofBlocks.add(block);
+        public void onBlockBreak(@NotNull BlockBreakEvent event) { //for vanilla shulkerbox
+            Block block = event.getBlock();
+
+            if (BlockStorage.isRebarBlock(block) || !block.getChunk().getPersistentDataContainer().has(getChunkPDC(block.getLocation()))) {
+                return;
+            }
+            ItemStack pdcItemStack = block.getChunk().getPersistentDataContainer()
+                    .get(getChunkPDC(block.getLocation()), RebarSerializers.ITEM_STACK);
+
+            if (block.getState() instanceof ShulkerBox box) {
+                event.setDropItems(false);
+                BlockStateMeta meta = (BlockStateMeta) pdcItemStack.getItemMeta();
+
+                meta.setBlockState(box);
+                pdcItemStack.setItemMeta(meta);
+
+                block.getWorld().dropItemNaturally(block.getLocation(), pdcItemStack);
+
+                block.getChunk().getPersistentDataContainer().remove(getChunkPDC(block.getLocation()));
             }
         }
 
         @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-        public void onSerialize(@NotNull RebarBlockSerializeEvent event) {
-            if (fireproofBlocks.contains(event.getRebarBlock())) {
-                event.getPdc().set(FIREPROOF_KEY, RebarSerializers.BOOLEAN, true);
-            }
-        }
+        public void onBlockDropItem(@NotNull BlockDropItemEvent event) { // for vanilla block
+            Block block = event.getBlock();
 
-        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-        public void onBlockBreak(@NotNull RebarBlockBreakEvent event) {
-            RebarBlock block = event.getRebarBlock();
-            if (!fireproofBlocks.remove(block)) {
+            if (!block.getChunk().getPersistentDataContainer().has(getChunkPDC(block.getLocation()))) {
                 return;
             }
 
+            ItemStack pdcItemStack = block.getChunk().getPersistentDataContainer()
+                    .get(getChunkPDC(block.getLocation()), RebarSerializers.ITEM_STACK);
+            for (Item item : event.getItems()) {
+                ItemStack itemStack = item.getItemStack();
+                if (pdcItemStack.getType() != itemStack.getType()) {
+                    continue;
+                }
+                event.getItems().remove(item);
+                block.getWorld().dropItemNaturally(block.getLocation(), pdcItemStack);
+                break;
+            }
+
+            block.getChunk().getPersistentDataContainer().remove(getChunkPDC(block.getLocation()));
+        }
+
+        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+        public void onRebarBlockBreak(@NotNull RebarBlockBreakEvent event) { // for rebar block
+            RebarBlock block = event.getRebarBlock();
+            if (!block.getBlock().getChunk().getPersistentDataContainer().has(getChunkPDC(block.getBlock().getLocation()))) {
+                return;
+            }
             for (ItemStack itemStack : event.getDrops()) {
                 RebarItemSchema dropSchema = RebarItemSchema.fromStack(itemStack);
                 if (dropSchema == null || !block.getKey().equals(dropSchema.getRebarBlockKey())) {
                     continue;
                 }
-
                 ItemStack fireproofStack = applyRune(itemStack, 1);
                 itemStack.subtract();
                 event.getDrops().add(fireproofStack);
                 break;
             }
+            block.getBlock().getChunk().getPersistentDataContainer().remove(getChunkPDC(block.getBlock().getLocation()));
         }
 
-        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-        public void onBlockUnload(@NotNull RebarBlockUnloadEvent event) {
-            fireproofBlocks.remove(event.getRebarBlock());
+        public NamespacedKey getChunkPDC(Location location) {
+            return pylonKey(String.format("%s_%d_%d_%d",
+                "fireproof", location.getBlockX(), location.getBlockY(), location.getBlockZ()));
         }
     }
 }

--- a/src/main/java/io/github/pylonmc/pylon/content/tools/FireproofRune.java
+++ b/src/main/java/io/github/pylonmc/pylon/content/tools/FireproofRune.java
@@ -2,12 +2,8 @@ package io.github.pylonmc.pylon.content.tools;
 
 import com.destroystokyo.paper.ParticleBuilder;
 import io.github.pylonmc.pylon.content.tools.base.Rune;
-import io.github.pylonmc.rebar.block.BlockStorage;
-import io.github.pylonmc.rebar.block.RebarBlock;
 import io.github.pylonmc.rebar.config.adapter.ConfigAdapter;
 import io.github.pylonmc.rebar.datatypes.RebarSerializers;
-import io.github.pylonmc.rebar.event.RebarBlockBreakEvent;
-import io.github.pylonmc.rebar.item.RebarItemSchema;
 import io.github.pylonmc.rebar.item.builder.ItemStackBuilder;
 import io.github.pylonmc.rebar.util.RandomizedSound;
 import io.papermc.paper.datacomponent.DataComponentTypes;
@@ -21,22 +17,11 @@ import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Particle;
 import org.bukkit.World;
-import org.bukkit.block.Block;
-import org.bukkit.block.ShulkerBox;
 import org.bukkit.damage.DamageType;
-import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.EventPriority;
-import org.bukkit.event.Listener;
-import org.bukkit.event.block.BlockBreakEvent;
-import org.bukkit.event.block.BlockDropItemEvent;
-import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.BlockStateMeta;
 import org.jetbrains.annotations.NotNull;
-
 
 import static io.github.pylonmc.pylon.util.PylonUtils.pylonKey;
 
@@ -141,89 +126,20 @@ public class FireproofRune extends Rune {
         return itemStack.getPersistentDataContainer().getOrDefault(FIREPROOF_KEY, RebarSerializers.BOOLEAN, false);
     }
 
-    public static class FireproofRuneListener implements Listener {
-        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-        public void onBlockPlace(BlockPlaceEvent event) { // use chunk pdc
-            ItemStack itemStack = event.getItemInHand();
-            if (itemStack == null || itemStack.isEmpty()) {
-                return;
-            }
-
-            Block block = event.getBlock();
-            if (hasRuneApplied(itemStack)) {
-                block.getChunk().getPersistentDataContainer()
-                    .set(getChunkPDC(block.getLocation()), RebarSerializers.ITEM_STACK, itemStack.asOne());
-            }
+    public static class FireproofRuneListener extends BlockRuneListener {
+        @Override
+        protected @NotNull String getKeyPrefix() {
+            return "fireproof";
         }
 
-        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-        public void onBlockBreak(@NotNull BlockBreakEvent event) { //for vanilla shulkerbox
-            Block block = event.getBlock();
-
-            if (BlockStorage.isRebarBlock(block) || !block.getChunk().getPersistentDataContainer().has(getChunkPDC(block.getLocation()))) {
-                return;
-            }
-            ItemStack pdcItemStack = block.getChunk().getPersistentDataContainer()
-                    .get(getChunkPDC(block.getLocation()), RebarSerializers.ITEM_STACK);
-
-            if (block.getState() instanceof ShulkerBox box) {
-                event.setDropItems(false);
-                BlockStateMeta meta = (BlockStateMeta) pdcItemStack.getItemMeta();
-
-                meta.setBlockState(box);
-                pdcItemStack.setItemMeta(meta);
-
-                block.getWorld().dropItemNaturally(block.getLocation(), pdcItemStack);
-
-                block.getChunk().getPersistentDataContainer().remove(getChunkPDC(block.getLocation()));
-            }
+        @Override
+        protected boolean hasRuneApplied(@NotNull ItemStack stack) {
+            return FireproofRune.hasRuneApplied(stack);
         }
 
-        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-        public void onBlockDropItem(@NotNull BlockDropItemEvent event) { // for vanilla block
-            Block block = event.getBlock();
-
-            if (!block.getChunk().getPersistentDataContainer().has(getChunkPDC(block.getLocation()))) {
-                return;
-            }
-
-            ItemStack pdcItemStack = block.getChunk().getPersistentDataContainer()
-                    .get(getChunkPDC(block.getLocation()), RebarSerializers.ITEM_STACK);
-            for (Item item : event.getItems()) {
-                ItemStack itemStack = item.getItemStack();
-                if (pdcItemStack.getType() != itemStack.getType()) {
-                    continue;
-                }
-                event.getItems().remove(item);
-                block.getWorld().dropItemNaturally(block.getLocation(), pdcItemStack);
-                break;
-            }
-
-            block.getChunk().getPersistentDataContainer().remove(getChunkPDC(block.getLocation()));
-        }
-
-        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-        public void onRebarBlockBreak(@NotNull RebarBlockBreakEvent event) { // for rebar block
-            RebarBlock block = event.getRebarBlock();
-            if (!block.getBlock().getChunk().getPersistentDataContainer().has(getChunkPDC(block.getBlock().getLocation()))) {
-                return;
-            }
-            for (ItemStack itemStack : event.getDrops()) {
-                RebarItemSchema dropSchema = RebarItemSchema.fromStack(itemStack);
-                if (dropSchema == null || !block.getKey().equals(dropSchema.getRebarBlockKey())) {
-                    continue;
-                }
-                ItemStack fireproofStack = applyRune(itemStack, 1);
-                itemStack.subtract();
-                event.getDrops().add(fireproofStack);
-                break;
-            }
-            block.getBlock().getChunk().getPersistentDataContainer().remove(getChunkPDC(block.getBlock().getLocation()));
-        }
-
-        public NamespacedKey getChunkPDC(Location location) {
-            return pylonKey(String.format("%s_%d_%d_%d",
-                "fireproof", location.getBlockX(), location.getBlockY(), location.getBlockZ()));
+        @Override
+        protected @NotNull ItemStack applyRune(@NotNull ItemStack stack, int amount) {
+            return FireproofRune.applyRune(stack, amount);
         }
     }
 }

--- a/src/main/java/io/github/pylonmc/pylon/content/tools/SoulboundRune.java
+++ b/src/main/java/io/github/pylonmc/pylon/content/tools/SoulboundRune.java
@@ -11,7 +11,6 @@ import io.github.pylonmc.rebar.event.RebarBlockUnloadEvent;
 import io.github.pylonmc.rebar.item.RebarItem;
 import io.github.pylonmc.rebar.item.RebarItemSchema;
 import io.github.pylonmc.rebar.item.builder.ItemStackBuilder;
-import io.papermc.paper.persistence.PersistentDataContainerView;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TranslatableComponent;
 import net.kyori.adventure.text.format.TextDecoration;
@@ -24,7 +23,6 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.persistence.PersistentDataContainer;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -47,19 +45,14 @@ public class SoulboundRune extends Rune {
 
     @Override
     public boolean isApplicableToTarget(@NotNull PlayerDropItemEvent event, @NotNull ItemStack rune, @NotNull ItemStack target) {
-        return !RebarItem.isRebarItem(target, SoulboundRune.class) && !target.getPersistentDataContainer().has(SOULBOUND_KEY);
+        return !RebarItem.isRebarItem(target, SoulboundRune.class) && !hasRuneApplied(target);
     }
 
     @Override
     public void onContactItem(@NotNull PlayerDropItemEvent event, @NotNull ItemStack rune, @NotNull ItemStack target) {
         int consume = Math.min(rune.getAmount(), target.getAmount());
 
-        ItemStack soulboundItem = ItemStackBuilder.of(target.asQuantity(consume))
-                .lore(TOOLTIP.decoration(TextDecoration.ITALIC, true))
-                .build();
-        soulboundItem.editPersistentDataContainer(pdc -> {
-            pdc.set(SOULBOUND_KEY, RebarSerializers.UUID, event.getPlayer().getUniqueId());
-        });
+        ItemStack soulboundItem = applyRune(target, consume);
 
         // (N)Either left runes or targets
         int leftRunes = rune.getAmount() - consume;
@@ -80,18 +73,33 @@ public class SoulboundRune extends Rune {
         event.getPlayer().sendMessage(SOULBIND_MSG);
     }
 
+    public static ItemStack applyRune(@NotNull ItemStack itemStack, int amount) {
+        return ItemStackBuilder.of(itemStack.asQuantity(amount))
+                .editPdc(pdc -> pdc.set(SOULBOUND_KEY, RebarSerializers.BOOLEAN, true))
+                .lore(TOOLTIP)
+                .build();
+    }
+
+    /**
+     * Checks if the target already has the soulbound rune applied
+     *
+     * @return true if the soulbound rune has been used on the item, false otherwise
+     */
+    public static boolean hasRuneApplied(@NotNull ItemStack itemStack) {
+        return itemStack.getPersistentDataContainer().getOrDefault(SOULBOUND_KEY, RebarSerializers.BOOLEAN, false);
+    }
+
     public static class SoulboundRuneListener implements Listener {
-        private final Map<RebarBlock, UUID> soulboundBlocks = new HashMap<>(); //use map to store uuid
+        private final List<RebarBlock> soulboundBlocks = new ArrayList<>();
 
         @EventHandler
         public void onPlayerDeath(PlayerDeathEvent event) { // exception being generated
-            Iterator<ItemStack> curItem = event.getDrops().iterator();
-            while (curItem.hasNext()) {
-                ItemStack curStack = curItem.next();
-                if (curStack == null || !curStack.hasItemMeta()) continue;
-                if (curStack.getItemMeta().getPersistentDataContainer().has(SOULBOUND_KEY)) {
-                    event.getItemsToKeep().add(curStack);
-                    curItem.remove();
+            Iterator<ItemStack> drops = event.getDrops().iterator();
+            while (drops.hasNext()) {
+                ItemStack drop = drops.next();
+                if (drop != null && hasRuneApplied(drop)) {
+                    event.getItemsToKeep().add(drop);
+                    drops.remove();
                 }
             }
         }
@@ -99,54 +107,47 @@ public class SoulboundRune extends Rune {
         @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
         public void onBlockPlace(RebarBlockPlaceEvent event) {
             ItemStack itemStack = event.getContext().getItem();
-            if (itemStack == null || itemStack.isEmpty()) return; //for safety
-            RebarBlock block = event.getRebarBlock();
-            PersistentDataContainerView pdcView = itemStack.getPersistentDataContainer();
-            if (pdcView.has(SOULBOUND_KEY)) {
-                soulboundBlocks.put(block, pdcView.get(SOULBOUND_KEY, RebarSerializers.UUID));
+            if (itemStack == null || itemStack.isEmpty()) {
+                return;
             }
-        }
 
-        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-        public void onBlockBreak(@NotNull RebarBlockBreakEvent event) {
-            RebarBlock block = event.getRebarBlock();
-            if (soulboundBlocks.containsKey(block)) {
-                UUID uuid = soulboundBlocks.remove(block);
-                for (ItemStack itemStack : event.getDrops()) {
-                    RebarItemSchema dropSchema = RebarItemSchema.fromStack(itemStack);  
-                    if (dropSchema == null) continue; //use schema to make sure as same as itself
-
-                    NamespacedKey blockItemKey = block.getSchema().getKey();
-                    if (blockItemKey == null || !dropSchema.getKey().equals(blockItemKey)) continue;
-
-                    List<Component> lore = new ArrayList<>(itemStack.lore());
-                    lore.add(Component.translatable("pylon.message.soulbound_rune.tooltip")
-                        .decoration(TextDecoration.ITALIC, true)); //make sure lore is italic
-                    itemStack.lore(lore);
-
-                    itemStack.editPersistentDataContainer(pdc -> 
-                        pdc.set(pylonKey("soulbound"), RebarSerializers.UUID, uuid));
-                    break;
-                }
-            }
-        }
-
-        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-        public void onSerialize(@NotNull RebarBlockSerializeEvent event) {
-            RebarBlock block = event.getRebarBlock();
-            PersistentDataContainer pdc = event.getPdc();
-            if (soulboundBlocks.containsKey(block)) {
-                UUID uuid = soulboundBlocks.get(block);
-                pdc.set(SOULBOUND_KEY, RebarSerializers.UUID, uuid);
+            if (hasRuneApplied(itemStack)) {
+                soulboundBlocks.add(event.getRebarBlock());
             }
         }
 
         @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
         public void onDeserialize(@NotNull RebarBlockDeserializeEvent event) {
             RebarBlock block = event.getRebarBlock();
-            PersistentDataContainer pdc = event.getPdc();
-            if (pdc.has(SOULBOUND_KEY) && !soulboundBlocks.containsKey(block)) {
-                soulboundBlocks.put(block, pdc.get(SOULBOUND_KEY, RebarSerializers.UUID));
+            if (event.getPdc().has(SOULBOUND_KEY) && !soulboundBlocks.contains(block)) {
+                soulboundBlocks.add(block);
+            }
+        }
+
+        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+        public void onSerialize(@NotNull RebarBlockSerializeEvent event) {
+            if (soulboundBlocks.contains(event.getRebarBlock())) {
+                event.getPdc().set(SOULBOUND_KEY, RebarSerializers.BOOLEAN, true);
+            }
+        }
+
+        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+        public void onBlockBreak(@NotNull RebarBlockBreakEvent event) {
+            RebarBlock block = event.getRebarBlock();
+            if (!soulboundBlocks.remove(block)) {
+                return;
+            }
+
+            for (ItemStack itemStack : event.getDrops()) {
+                RebarItemSchema dropSchema = RebarItemSchema.fromStack(itemStack);
+                if (dropSchema == null || !block.getKey().equals(dropSchema.getRebarBlockKey())) {
+                    continue;
+                }
+
+                ItemStack soulboundStack = applyRune(itemStack, 1);
+                itemStack.subtract();
+                event.getDrops().add(soulboundStack);
+                break;
             }
         }
 

--- a/src/main/java/io/github/pylonmc/pylon/content/tools/SoulboundRune.java
+++ b/src/main/java/io/github/pylonmc/pylon/content/tools/SoulboundRune.java
@@ -1,7 +1,13 @@
 package io.github.pylonmc.pylon.content.tools;
 
 import io.github.pylonmc.pylon.content.tools.base.Rune;
+import io.github.pylonmc.rebar.block.RebarBlock;
+import io.github.pylonmc.rebar.block.context.BlockBreakContext.PlayerBreak;
 import io.github.pylonmc.rebar.datatypes.RebarSerializers;
+import io.github.pylonmc.rebar.event.RebarBlockBreakEvent;
+import io.github.pylonmc.rebar.event.RebarBlockDeserializeEvent;
+import io.github.pylonmc.rebar.event.RebarBlockPlaceEvent;
+import io.github.pylonmc.rebar.event.RebarBlockSerializeEvent;
 import io.github.pylonmc.rebar.item.RebarItem;
 import io.github.pylonmc.rebar.item.builder.ItemStackBuilder;
 import net.kyori.adventure.text.Component;
@@ -10,14 +16,19 @@ import net.kyori.adventure.translation.GlobalTranslator;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.World;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.persistence.PersistentDataContainer;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 
 import static io.github.pylonmc.pylon.util.PylonUtils.pylonKey;
 
@@ -77,6 +88,51 @@ public class SoulboundRune extends Rune {
                     curItem.remove();
                 }
             }
+        }
+
+        private List<RebarBlock> soulbound_blocks = new ArrayList<>();
+        
+        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+        public void onBlockPlace(RebarBlockPlaceEvent event) {
+            ItemStack itemStack = event.getContext().getItem().asOne();
+            RebarBlock block = event.getRebarBlock();
+
+            if (itemStack.getPersistentDataContainer().has(SOULBOUND_KEY)) {
+                soulbound_blocks.add(block);
+            }
+        }
+
+        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+        public void onBlockBreak(@NotNull RebarBlockBreakEvent event) {
+            RebarBlock block = event.getRebarBlock();
+            if (!(event.getContext() instanceof PlayerBreak playerBreak)) return;
+            Player player = playerBreak.event().getPlayer();
+            if (soulbound_blocks.contains(block)) {
+                soulbound_blocks.remove(block);
+                for (ItemStack itemStack : event.getDrops()) {
+                    List<Component> lore = new ArrayList<>(itemStack.lore());
+                    
+                    lore.add(GlobalTranslator.render(Component.translatable("pylon.message.soulbound_rune.tooltip"), player.locale()));
+                    itemStack.editPersistentDataContainer(pdc -> 
+                        pdc.set(pylonKey("soulbound"), RebarSerializers.UUID, player.getUniqueId()));
+                    
+                    itemStack.lore(lore);
+                }
+            }
+        }
+
+        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+        public void onSerialize(@NotNull RebarBlockSerializeEvent event) {
+            RebarBlock block = event.getRebarBlock();
+            PersistentDataContainer pdc = event.getPdc();
+            if (soulbound_blocks.contains(block)) pdc.set(SOULBOUND_KEY, RebarSerializers.BOOLEAN, true);
+        }
+
+        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+        public void onDeserialize(@NotNull RebarBlockDeserializeEvent event) {
+            RebarBlock block = event.getRebarBlock();
+            PersistentDataContainer pdc = event.getPdc();
+            if (pdc.has(SOULBOUND_KEY) && !soulbound_blocks.contains(block)) soulbound_blocks.add(block);
         }
     }
 }

--- a/src/main/java/io/github/pylonmc/pylon/content/tools/SoulboundRune.java
+++ b/src/main/java/io/github/pylonmc/pylon/content/tools/SoulboundRune.java
@@ -2,21 +2,22 @@ package io.github.pylonmc.pylon.content.tools;
 
 import io.github.pylonmc.pylon.content.tools.base.Rune;
 import io.github.pylonmc.rebar.block.RebarBlock;
-import io.github.pylonmc.rebar.block.context.BlockBreakContext.PlayerBreak;
 import io.github.pylonmc.rebar.datatypes.RebarSerializers;
 import io.github.pylonmc.rebar.event.RebarBlockBreakEvent;
 import io.github.pylonmc.rebar.event.RebarBlockDeserializeEvent;
 import io.github.pylonmc.rebar.event.RebarBlockPlaceEvent;
 import io.github.pylonmc.rebar.event.RebarBlockSerializeEvent;
+import io.github.pylonmc.rebar.event.RebarBlockUnloadEvent;
 import io.github.pylonmc.rebar.item.RebarItem;
+import io.github.pylonmc.rebar.item.RebarItemSchema;
 import io.github.pylonmc.rebar.item.builder.ItemStackBuilder;
+import io.papermc.paper.persistence.PersistentDataContainerView;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TranslatableComponent;
-import net.kyori.adventure.translation.GlobalTranslator;
+import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.World;
-import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -27,8 +28,11 @@ import org.bukkit.persistence.PersistentDataContainer;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 import static io.github.pylonmc.pylon.util.PylonUtils.pylonKey;
 
@@ -51,7 +55,7 @@ public class SoulboundRune extends Rune {
         int consume = Math.min(rune.getAmount(), target.getAmount());
 
         ItemStack soulboundItem = ItemStackBuilder.of(target.asQuantity(consume))
-                .lore(GlobalTranslator.render(TOOLTIP, event.getPlayer().locale()))
+                .lore(TOOLTIP.decoration(TextDecoration.ITALIC, true))
                 .build();
         soulboundItem.editPersistentDataContainer(pdc -> {
             pdc.set(SOULBOUND_KEY, RebarSerializers.UUID, event.getPlayer().getUniqueId());
@@ -77,6 +81,8 @@ public class SoulboundRune extends Rune {
     }
 
     public static class SoulboundRuneListener implements Listener {
+        private final Map<RebarBlock, UUID> soulboundBlocks = new HashMap<>(); //use map to store uuid
+
         @EventHandler
         public void onPlayerDeath(PlayerDeathEvent event) { // exception being generated
             Iterator<ItemStack> curItem = event.getDrops().iterator();
@@ -89,34 +95,38 @@ public class SoulboundRune extends Rune {
                 }
             }
         }
-
-        private List<RebarBlock> soulbound_blocks = new ArrayList<>();
         
         @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
         public void onBlockPlace(RebarBlockPlaceEvent event) {
-            ItemStack itemStack = event.getContext().getItem().asOne();
+            ItemStack itemStack = event.getContext().getItem();
+            if (itemStack == null || itemStack.isEmpty()) return; //for safety
             RebarBlock block = event.getRebarBlock();
-
-            if (itemStack.getPersistentDataContainer().has(SOULBOUND_KEY)) {
-                soulbound_blocks.add(block);
+            PersistentDataContainerView pdcView = itemStack.getPersistentDataContainer();
+            if (pdcView.has(SOULBOUND_KEY)) {
+                soulboundBlocks.put(block, pdcView.get(SOULBOUND_KEY, RebarSerializers.UUID));
             }
         }
 
         @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
         public void onBlockBreak(@NotNull RebarBlockBreakEvent event) {
             RebarBlock block = event.getRebarBlock();
-            if (!(event.getContext() instanceof PlayerBreak playerBreak)) return;
-            Player player = playerBreak.event().getPlayer();
-            if (soulbound_blocks.contains(block)) {
-                soulbound_blocks.remove(block);
+            if (soulboundBlocks.containsKey(block)) {
+                UUID uuid = soulboundBlocks.remove(block);
                 for (ItemStack itemStack : event.getDrops()) {
+                    RebarItemSchema dropSchema = RebarItemSchema.fromStack(itemStack);  
+                    if (dropSchema == null) continue; //use schema to make sure as same as itself
+
+                    NamespacedKey blockItemKey = block.getSchema().getKey();
+                    if (blockItemKey == null || !dropSchema.getKey().equals(blockItemKey)) continue;
+
                     List<Component> lore = new ArrayList<>(itemStack.lore());
-                    
-                    lore.add(GlobalTranslator.render(Component.translatable("pylon.message.soulbound_rune.tooltip"), player.locale()));
-                    itemStack.editPersistentDataContainer(pdc -> 
-                        pdc.set(pylonKey("soulbound"), RebarSerializers.UUID, player.getUniqueId()));
-                    
+                    lore.add(Component.translatable("pylon.message.soulbound_rune.tooltip")
+                        .decoration(TextDecoration.ITALIC, true)); //make sure lore is italic
                     itemStack.lore(lore);
+
+                    itemStack.editPersistentDataContainer(pdc -> 
+                        pdc.set(pylonKey("soulbound"), RebarSerializers.UUID, uuid));
+                    break;
                 }
             }
         }
@@ -125,14 +135,24 @@ public class SoulboundRune extends Rune {
         public void onSerialize(@NotNull RebarBlockSerializeEvent event) {
             RebarBlock block = event.getRebarBlock();
             PersistentDataContainer pdc = event.getPdc();
-            if (soulbound_blocks.contains(block)) pdc.set(SOULBOUND_KEY, RebarSerializers.BOOLEAN, true);
+            if (soulboundBlocks.containsKey(block)) {
+                UUID uuid = soulboundBlocks.get(block);
+                pdc.set(SOULBOUND_KEY, RebarSerializers.UUID, uuid);
+            }
         }
 
         @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
         public void onDeserialize(@NotNull RebarBlockDeserializeEvent event) {
             RebarBlock block = event.getRebarBlock();
             PersistentDataContainer pdc = event.getPdc();
-            if (pdc.has(SOULBOUND_KEY) && !soulbound_blocks.contains(block)) soulbound_blocks.add(block);
+            if (pdc.has(SOULBOUND_KEY) && !soulboundBlocks.containsKey(block)) {
+                soulboundBlocks.put(block, pdc.get(SOULBOUND_KEY, RebarSerializers.UUID));
+            }
+        }
+
+        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+        public void onBlockUnload(@NotNull RebarBlockUnloadEvent event) { //add unload event
+            soulboundBlocks.remove(event.getRebarBlock());
         }
     }
 }

--- a/src/main/java/io/github/pylonmc/pylon/content/tools/SoulboundRune.java
+++ b/src/main/java/io/github/pylonmc/pylon/content/tools/SoulboundRune.java
@@ -1,31 +1,18 @@
 package io.github.pylonmc.pylon.content.tools;
 
 import io.github.pylonmc.pylon.content.tools.base.Rune;
-import io.github.pylonmc.rebar.block.BlockStorage;
-import io.github.pylonmc.rebar.block.RebarBlock;
 import io.github.pylonmc.rebar.datatypes.RebarSerializers;
-import io.github.pylonmc.rebar.event.RebarBlockBreakEvent;
 import io.github.pylonmc.rebar.item.RebarItem;
-import io.github.pylonmc.rebar.item.RebarItemSchema;
 import io.github.pylonmc.rebar.item.builder.ItemStackBuilder;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TranslatableComponent;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.World;
-import org.bukkit.block.Block;
-import org.bukkit.block.ShulkerBox;
-import org.bukkit.entity.Item;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.EventPriority;
-import org.bukkit.event.Listener;
-import org.bukkit.event.block.BlockBreakEvent;
-import org.bukkit.event.block.BlockDropItemEvent;
-import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.BlockStateMeta;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Iterator;
@@ -87,9 +74,8 @@ public class SoulboundRune extends Rune {
         return itemStack.getPersistentDataContainer().getOrDefault(SOULBOUND_KEY, RebarSerializers.BOOLEAN, false);
     }
 
-    public static class SoulboundRuneListener implements Listener {
-
-        @EventHandler
+   public static class SoulboundRuneListener extends BlockRuneListener {
+        @EventHandler(ignoreCancelled = true)
         public void onPlayerDeath(PlayerDeathEvent event) { // exception being generated
             Iterator<ItemStack> drops = event.getDrops().iterator();
             while (drops.hasNext()) {
@@ -101,90 +87,19 @@ public class SoulboundRune extends Rune {
             }
         }
         
-        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-        public void onBlockPlace(BlockPlaceEvent event) { // use chunk pdc
-            ItemStack itemStack = event.getItemInHand();
-            if (itemStack == null || itemStack.isEmpty()) {
-                return;
-            }
-
-            Block block = event.getBlock();
-            if (hasRuneApplied(itemStack)) {
-                block.getChunk().getPersistentDataContainer()
-                    .set(getChunkPDC(block.getLocation()), RebarSerializers.ITEM_STACK, itemStack.asOne());
-            }
+        @Override
+        protected @NotNull String getKeyPrefix() {
+            return "soulbound";
         }
 
-        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-        public void onBlockBreak(@NotNull BlockBreakEvent event) { //for vanilla shulkerbox
-            Block block = event.getBlock();
-
-            if (BlockStorage.isRebarBlock(block) || !block.getChunk().getPersistentDataContainer().has(getChunkPDC(block.getLocation()))) {
-                return;
-            }
-            ItemStack pdcItemStack = block.getChunk().getPersistentDataContainer()
-                    .get(getChunkPDC(block.getLocation()), RebarSerializers.ITEM_STACK);
-
-            if (block.getState() instanceof ShulkerBox box) {
-                event.setDropItems(false);
-                BlockStateMeta meta = (BlockStateMeta) pdcItemStack.getItemMeta();
-
-                meta.setBlockState(box);
-                pdcItemStack.setItemMeta(meta);
-
-                block.getWorld().dropItemNaturally(block.getLocation(), pdcItemStack);
-
-                block.getChunk().getPersistentDataContainer().remove(getChunkPDC(block.getLocation()));
-            }
+        @Override
+        protected boolean hasRuneApplied(@NotNull ItemStack stack) {
+            return SoulboundRune.hasRuneApplied(stack);
         }
 
-        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-        public void onBlockDropItem(@NotNull BlockDropItemEvent event) { // for vanilla block
-            Block block = event.getBlock();
-
-            if (!block.getChunk().getPersistentDataContainer().has(getChunkPDC(block.getLocation()))) {
-                return;
-            }
-
-            ItemStack pdcItemStack = block.getChunk().getPersistentDataContainer()
-                    .get(getChunkPDC(block.getLocation()), RebarSerializers.ITEM_STACK);
-            for (Item item : event.getItems()) {
-                ItemStack itemStack = item.getItemStack();
-                if (pdcItemStack.getType() != itemStack.getType()) {
-                    continue;
-                }
-                event.getItems().remove(item);
-                block.getWorld().dropItemNaturally(block.getLocation(), pdcItemStack);
-                break;
-            }
-
-            block.getChunk().getPersistentDataContainer().remove(getChunkPDC(block.getLocation()));
-        }
-
-        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-        public void onRebarBlockBreak(@NotNull RebarBlockBreakEvent event) { // for rebar block
-            RebarBlock block = event.getRebarBlock();
-            if (!block.getBlock().getChunk().getPersistentDataContainer().has(getChunkPDC(block.getBlock().getLocation()))) {
-                return;
-            }
-
-            for (ItemStack itemStack : event.getDrops()) {
-                RebarItemSchema dropSchema = RebarItemSchema.fromStack(itemStack);
-                if (dropSchema == null || !block.getKey().equals(dropSchema.getRebarBlockKey())) {
-                    continue;
-                }
-
-                ItemStack soulboundStack = applyRune(itemStack, 1);
-                itemStack.subtract();
-                event.getDrops().add(soulboundStack);
-                break;
-            }
-            block.getBlock().getChunk().getPersistentDataContainer().remove(getChunkPDC(block.getBlock().getLocation()));
-        }
-
-        public NamespacedKey getChunkPDC(Location location) {
-            return pylonKey(String.format("%s_%d_%d_%d",
-                "soulbound", location.getBlockX(), location.getBlockY(), location.getBlockZ()));
+        @Override
+        protected @NotNull ItemStack applyRune(@NotNull ItemStack stack, int amount) {
+            return SoulboundRune.applyRune(stack, amount);
         }
     }
 }

--- a/src/main/java/io/github/pylonmc/pylon/content/tools/SoulboundRune.java
+++ b/src/main/java/io/github/pylonmc/pylon/content/tools/SoulboundRune.java
@@ -1,36 +1,34 @@
 package io.github.pylonmc.pylon.content.tools;
 
 import io.github.pylonmc.pylon.content.tools.base.Rune;
+import io.github.pylonmc.rebar.block.BlockStorage;
 import io.github.pylonmc.rebar.block.RebarBlock;
 import io.github.pylonmc.rebar.datatypes.RebarSerializers;
 import io.github.pylonmc.rebar.event.RebarBlockBreakEvent;
-import io.github.pylonmc.rebar.event.RebarBlockDeserializeEvent;
-import io.github.pylonmc.rebar.event.RebarBlockPlaceEvent;
-import io.github.pylonmc.rebar.event.RebarBlockSerializeEvent;
-import io.github.pylonmc.rebar.event.RebarBlockUnloadEvent;
 import io.github.pylonmc.rebar.item.RebarItem;
 import io.github.pylonmc.rebar.item.RebarItemSchema;
 import io.github.pylonmc.rebar.item.builder.ItemStackBuilder;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TranslatableComponent;
-import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.ShulkerBox;
+import org.bukkit.entity.Item;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockDropItemEvent;
+import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.BlockStateMeta;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
 
 import static io.github.pylonmc.pylon.util.PylonUtils.pylonKey;
 
@@ -90,7 +88,6 @@ public class SoulboundRune extends Rune {
     }
 
     public static class SoulboundRuneListener implements Listener {
-        private final List<RebarBlock> soulboundBlocks = new ArrayList<>();
 
         @EventHandler
         public void onPlayerDeath(PlayerDeathEvent event) { // exception being generated
@@ -105,36 +102,69 @@ public class SoulboundRune extends Rune {
         }
         
         @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-        public void onBlockPlace(RebarBlockPlaceEvent event) {
-            ItemStack itemStack = event.getContext().getItem();
+        public void onBlockPlace(BlockPlaceEvent event) { // use chunk pdc
+            ItemStack itemStack = event.getItemInHand();
             if (itemStack == null || itemStack.isEmpty()) {
                 return;
             }
 
+            Block block = event.getBlock();
             if (hasRuneApplied(itemStack)) {
-                soulboundBlocks.add(event.getRebarBlock());
+                block.getChunk().getPersistentDataContainer()
+                    .set(getChunkPDC(block.getLocation()), RebarSerializers.ITEM_STACK, itemStack.asOne());
             }
         }
 
         @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-        public void onDeserialize(@NotNull RebarBlockDeserializeEvent event) {
+        public void onBlockBreak(@NotNull BlockBreakEvent event) { //for vanilla shulkerbox
+            Block block = event.getBlock();
+
+            if (BlockStorage.isRebarBlock(block) || !block.getChunk().getPersistentDataContainer().has(getChunkPDC(block.getLocation()))) {
+                return;
+            }
+            ItemStack pdcItemStack = block.getChunk().getPersistentDataContainer()
+                    .get(getChunkPDC(block.getLocation()), RebarSerializers.ITEM_STACK);
+
+            if (block.getState() instanceof ShulkerBox box) {
+                event.setDropItems(false);
+                BlockStateMeta meta = (BlockStateMeta) pdcItemStack.getItemMeta();
+
+                meta.setBlockState(box);
+                pdcItemStack.setItemMeta(meta);
+
+                block.getWorld().dropItemNaturally(block.getLocation(), pdcItemStack);
+
+                block.getChunk().getPersistentDataContainer().remove(getChunkPDC(block.getLocation()));
+            }
+        }
+
+        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+        public void onBlockDropItem(@NotNull BlockDropItemEvent event) { // for vanilla block
+            Block block = event.getBlock();
+
+            if (!block.getChunk().getPersistentDataContainer().has(getChunkPDC(block.getLocation()))) {
+                return;
+            }
+
+            ItemStack pdcItemStack = block.getChunk().getPersistentDataContainer()
+                    .get(getChunkPDC(block.getLocation()), RebarSerializers.ITEM_STACK);
+            for (Item item : event.getItems()) {
+                ItemStack itemStack = item.getItemStack();
+                if (pdcItemStack.getType() != itemStack.getType()) {
+                    continue;
+                }
+                event.getItems().remove(item);
+                block.getWorld().dropItemNaturally(block.getLocation(), pdcItemStack);
+                break;
+            }
+
+            block.getChunk().getPersistentDataContainer().remove(getChunkPDC(block.getLocation()));
+        }
+
+        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+        public void onRebarBlockBreak(@NotNull RebarBlockBreakEvent event) { // for rebar block
             RebarBlock block = event.getRebarBlock();
-            if (event.getPdc().has(SOULBOUND_KEY) && !soulboundBlocks.contains(block)) {
-                soulboundBlocks.add(block);
-            }
-        }
-
-        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-        public void onSerialize(@NotNull RebarBlockSerializeEvent event) {
-            if (soulboundBlocks.contains(event.getRebarBlock())) {
-                event.getPdc().set(SOULBOUND_KEY, RebarSerializers.BOOLEAN, true);
-            }
-        }
-
-        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-        public void onBlockBreak(@NotNull RebarBlockBreakEvent event) {
-            RebarBlock block = event.getRebarBlock();
-            if (!soulboundBlocks.remove(block)) {
+            if (!block.getBlock().getChunk().getPersistentDataContainer().has(getChunkPDC(block.getBlock().getLocation()))) {
                 return;
             }
 
@@ -149,11 +179,12 @@ public class SoulboundRune extends Rune {
                 event.getDrops().add(soulboundStack);
                 break;
             }
+            block.getBlock().getChunk().getPersistentDataContainer().remove(getChunkPDC(block.getBlock().getLocation()));
         }
 
-        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-        public void onBlockUnload(@NotNull RebarBlockUnloadEvent event) { //add unload event
-            soulboundBlocks.remove(event.getRebarBlock());
+        public NamespacedKey getChunkPDC(Location location) {
+            return pylonKey(String.format("%s_%d_%d_%d",
+                "soulbound", location.getBlockX(), location.getBlockY(), location.getBlockZ()));
         }
     }
 }

--- a/src/main/java/io/github/pylonmc/pylon/content/tools/base/Rune.java
+++ b/src/main/java/io/github/pylonmc/pylon/content/tools/base/Rune.java
@@ -2,11 +2,6 @@ package io.github.pylonmc.pylon.content.tools.base;
 
 import io.github.pylonmc.pylon.Pylon;
 import io.github.pylonmc.pylon.PylonConfig;
-import io.github.pylonmc.pylon.content.tools.FireproofRune;
-import io.github.pylonmc.rebar.block.context.BlockBreakContext.PlayerBreak;
-import io.github.pylonmc.rebar.datatypes.RebarSerializers;
-import io.github.pylonmc.rebar.event.RebarBlockBreakEvent;
-import io.github.pylonmc.rebar.event.RebarBlockPlaceEvent;
 import io.github.pylonmc.rebar.item.RebarItem;
 import io.github.pylonmc.rebar.item.RebarItemSchema;
 import io.github.pylonmc.rebar.item.interfaces.ArrowRebarItemHandler;
@@ -14,14 +9,8 @@ import io.github.pylonmc.rebar.item.interfaces.BlockBreakRebarItemHandler;
 import io.github.pylonmc.rebar.item.interfaces.BowRebarItemHandler;
 import io.github.pylonmc.rebar.item.interfaces.BucketRebarItemHandler;
 import io.github.pylonmc.rebar.item.interfaces.EntityAttackRebarItemHandler;
-import io.papermc.paper.datacomponent.DataComponentTypes;
-import io.papermc.paper.datacomponent.item.DamageResistant;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.translation.GlobalTranslator;
 
 import org.bukkit.Bukkit;
-import org.bukkit.NamespacedKey;
-import org.bukkit.block.Block;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -31,9 +20,6 @@ import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
-import static io.github.pylonmc.pylon.util.PylonUtils.pylonKey;
-
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -87,8 +73,6 @@ public abstract class Rune extends RebarItem {
     public abstract void onContactItem(@NotNull PlayerDropItemEvent event, @NotNull ItemStack rune, @NotNull ItemStack target);
 
     public static class RuneListener implements Listener {
-        private static final String soulbound_prefix = "block_soulbound";
-        private static final String fireproof_prefix = "block_fireproof";
 
         @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
         void onRuneDrop(@NotNull PlayerDropItemEvent event) {
@@ -130,51 +114,6 @@ public abstract class Rune extends RebarItem {
                 runeEntity.setItemStack(runeStack);
                 targetEntity.setItemStack(target);
             }, 1, 2);
-        }
-        
-        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-        public void onBlockPlace(RebarBlockPlaceEvent event) {
-            ItemStack itemStack = event.getContext().getItem().asOne();
-            Block block = event.getBlock();
-            if (itemStack.getPersistentDataContainer().has(pylonKey("soulbound"))) {
-                block.getChunk().getPersistentDataContainer()
-                    .set(newKey(soulbound_prefix, block), RebarSerializers.BOOLEAN, true);
-            }
-            if (itemStack.getData(DataComponentTypes.DAMAGE_RESISTANT) == null ? false
-                        : itemStack.getData(DataComponentTypes.DAMAGE_RESISTANT).types().equals(FireproofRune.IS_FIRE_TAG)) {
-                block.getChunk().getPersistentDataContainer()
-                    .set(newKey(fireproof_prefix, block), RebarSerializers.BOOLEAN, true);
-            }
-        }
-        
-        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-        public void onBlockBreak(@NotNull RebarBlockBreakEvent event) {
-            Block block = event.getBlock();
-            if (!(event.getContext() instanceof PlayerBreak playerBreak)) return;
-            Player player = playerBreak.event().getPlayer();
-            Boolean soulbound = block.getChunk().getPersistentDataContainer()
-                .getOrDefault(newKey(soulbound_prefix, block), RebarSerializers.BOOLEAN, false);
-            Boolean fireproof = block.getChunk().getPersistentDataContainer()
-                .getOrDefault(newKey(fireproof_prefix, block), RebarSerializers.BOOLEAN, false);
-            for (ItemStack itemStack : event.getDrops()) {
-                List<Component> lore = new ArrayList<>(itemStack.lore());
-                if (soulbound) {
-                    lore.add(GlobalTranslator.render(Component.translatable("pylon.message.soulbound_rune.tooltip"), player.locale()));
-                    itemStack.editPersistentDataContainer(pdc -> 
-                    pdc.set(pylonKey("soulbound"), RebarSerializers.UUID, player.getUniqueId()));
-                    block.getChunk().getPersistentDataContainer().remove(newKey(soulbound_prefix, block));
-                }
-                if (fireproof) {
-                    lore.add(GlobalTranslator.render(Component.translatable("pylon.message.fireproof_result.tooltip"), player.locale()));
-                    itemStack.setData(DataComponentTypes.DAMAGE_RESISTANT, DamageResistant.damageResistant(FireproofRune.IS_FIRE_TAG));
-                    block.getChunk().getPersistentDataContainer().remove(newKey(fireproof_prefix, block));
-                }
-                itemStack.lore(lore);
-            }
-        }
-        private NamespacedKey newKey(String type, Block block) {
-            return pylonKey(String.format("%s_%d_%d_%d",
-                type, block.getLocation().getBlockX(), block.getLocation().getBlockY(), block.getLocation().getBlockZ()));
         }
     }
 }

--- a/src/main/java/io/github/pylonmc/pylon/content/tools/base/Rune.java
+++ b/src/main/java/io/github/pylonmc/pylon/content/tools/base/Rune.java
@@ -9,7 +9,6 @@ import io.github.pylonmc.rebar.item.interfaces.BlockBreakRebarItemHandler;
 import io.github.pylonmc.rebar.item.interfaces.BowRebarItemHandler;
 import io.github.pylonmc.rebar.item.interfaces.BucketRebarItemHandler;
 import io.github.pylonmc.rebar.item.interfaces.EntityAttackRebarItemHandler;
-
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
@@ -73,7 +72,6 @@ public abstract class Rune extends RebarItem {
     public abstract void onContactItem(@NotNull PlayerDropItemEvent event, @NotNull ItemStack rune, @NotNull ItemStack target);
 
     public static class RuneListener implements Listener {
-
         @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
         void onRuneDrop(@NotNull PlayerDropItemEvent event) {
             Player player = event.getPlayer();

--- a/src/main/java/io/github/pylonmc/pylon/content/tools/base/Rune.java
+++ b/src/main/java/io/github/pylonmc/pylon/content/tools/base/Rune.java
@@ -2,6 +2,11 @@ package io.github.pylonmc.pylon.content.tools.base;
 
 import io.github.pylonmc.pylon.Pylon;
 import io.github.pylonmc.pylon.PylonConfig;
+import io.github.pylonmc.pylon.content.tools.FireproofRune;
+import io.github.pylonmc.rebar.block.context.BlockBreakContext.PlayerBreak;
+import io.github.pylonmc.rebar.datatypes.RebarSerializers;
+import io.github.pylonmc.rebar.event.RebarBlockBreakEvent;
+import io.github.pylonmc.rebar.event.RebarBlockPlaceEvent;
 import io.github.pylonmc.rebar.item.RebarItem;
 import io.github.pylonmc.rebar.item.RebarItemSchema;
 import io.github.pylonmc.rebar.item.interfaces.ArrowRebarItemHandler;
@@ -9,7 +14,14 @@ import io.github.pylonmc.rebar.item.interfaces.BlockBreakRebarItemHandler;
 import io.github.pylonmc.rebar.item.interfaces.BowRebarItemHandler;
 import io.github.pylonmc.rebar.item.interfaces.BucketRebarItemHandler;
 import io.github.pylonmc.rebar.item.interfaces.EntityAttackRebarItemHandler;
+import io.papermc.paper.datacomponent.DataComponentTypes;
+import io.papermc.paper.datacomponent.item.DamageResistant;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.translation.GlobalTranslator;
+
 import org.bukkit.Bukkit;
+import org.bukkit.NamespacedKey;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -19,6 +31,9 @@ import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
+import static io.github.pylonmc.pylon.util.PylonUtils.pylonKey;
+
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -72,6 +87,9 @@ public abstract class Rune extends RebarItem {
     public abstract void onContactItem(@NotNull PlayerDropItemEvent event, @NotNull ItemStack rune, @NotNull ItemStack target);
 
     public static class RuneListener implements Listener {
+        private static final String soulbound_prefix = "block_soulbound";
+        private static final String fireproof_prefix = "block_fireproof";
+
         @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
         void onRuneDrop(@NotNull PlayerDropItemEvent event) {
             Player player = event.getPlayer();
@@ -112,6 +130,51 @@ public abstract class Rune extends RebarItem {
                 runeEntity.setItemStack(runeStack);
                 targetEntity.setItemStack(target);
             }, 1, 2);
+        }
+        
+        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+        public void onBlockPlace(RebarBlockPlaceEvent event) {
+            ItemStack itemStack = event.getContext().getItem().asOne();
+            Block block = event.getBlock();
+            if (itemStack.getPersistentDataContainer().has(pylonKey("soulbound"))) {
+                block.getChunk().getPersistentDataContainer()
+                    .set(newKey(soulbound_prefix, block), RebarSerializers.BOOLEAN, true);
+            }
+            if (itemStack.getData(DataComponentTypes.DAMAGE_RESISTANT) == null ? false
+                        : itemStack.getData(DataComponentTypes.DAMAGE_RESISTANT).types().equals(FireproofRune.IS_FIRE_TAG)) {
+                block.getChunk().getPersistentDataContainer()
+                    .set(newKey(fireproof_prefix, block), RebarSerializers.BOOLEAN, true);
+            }
+        }
+        
+        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+        public void onBlockBreak(@NotNull RebarBlockBreakEvent event) {
+            Block block = event.getBlock();
+            if (!(event.getContext() instanceof PlayerBreak playerBreak)) return;
+            Player player = playerBreak.event().getPlayer();
+            Boolean soulbound = block.getChunk().getPersistentDataContainer()
+                .getOrDefault(newKey(soulbound_prefix, block), RebarSerializers.BOOLEAN, false);
+            Boolean fireproof = block.getChunk().getPersistentDataContainer()
+                .getOrDefault(newKey(fireproof_prefix, block), RebarSerializers.BOOLEAN, false);
+            for (ItemStack itemStack : event.getDrops()) {
+                List<Component> lore = new ArrayList<>(itemStack.lore());
+                if (soulbound) {
+                    lore.add(GlobalTranslator.render(Component.translatable("pylon.message.soulbound_rune.tooltip"), player.locale()));
+                    itemStack.editPersistentDataContainer(pdc -> 
+                    pdc.set(pylonKey("soulbound"), RebarSerializers.UUID, player.getUniqueId()));
+                    block.getChunk().getPersistentDataContainer().remove(newKey(soulbound_prefix, block));
+                }
+                if (fireproof) {
+                    lore.add(GlobalTranslator.render(Component.translatable("pylon.message.fireproof_result.tooltip"), player.locale()));
+                    itemStack.setData(DataComponentTypes.DAMAGE_RESISTANT, DamageResistant.damageResistant(FireproofRune.IS_FIRE_TAG));
+                    block.getChunk().getPersistentDataContainer().remove(newKey(fireproof_prefix, block));
+                }
+                itemStack.lore(lore);
+            }
+        }
+        private NamespacedKey newKey(String type, Block block) {
+            return pylonKey(String.format("%s_%d_%d_%d",
+                type, block.getLocation().getBlockX(), block.getLocation().getBlockY(), block.getLocation().getBlockZ()));
         }
     }
 }

--- a/src/main/java/io/github/pylonmc/pylon/content/tools/base/Rune.java
+++ b/src/main/java/io/github/pylonmc/pylon/content/tools/base/Rune.java
@@ -2,6 +2,10 @@ package io.github.pylonmc.pylon.content.tools.base;
 
 import io.github.pylonmc.pylon.Pylon;
 import io.github.pylonmc.pylon.PylonConfig;
+import io.github.pylonmc.pylon.util.PylonUtils;
+import io.github.pylonmc.rebar.block.RebarBlock;
+import io.github.pylonmc.rebar.datatypes.RebarSerializers;
+import io.github.pylonmc.rebar.event.RebarBlockBreakEvent;
 import io.github.pylonmc.rebar.item.RebarItem;
 import io.github.pylonmc.rebar.item.RebarItemSchema;
 import io.github.pylonmc.rebar.item.interfaces.ArrowRebarItemHandler;
@@ -9,16 +13,25 @@ import io.github.pylonmc.rebar.item.interfaces.BlockBreakRebarItemHandler;
 import io.github.pylonmc.rebar.item.interfaces.BowRebarItemHandler;
 import io.github.pylonmc.rebar.item.interfaces.BucketRebarItemHandler;
 import io.github.pylonmc.rebar.item.interfaces.EntityAttackRebarItemHandler;
+import io.papermc.paper.datacomponent.DataComponentTypes;
+import io.papermc.paper.datacomponent.item.ItemContainerContents;
+
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockDropItemEvent;
+import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -112,6 +125,114 @@ public abstract class Rune extends RebarItem {
                 runeEntity.setItemStack(runeStack);
                 targetEntity.setItemStack(target);
             }, 1, 2);
+        }
+    }
+
+    public static abstract class BlockRuneListener implements Listener { //abstract listener
+        private static final String RUNE_PREFIX = "rune"; //for vanilla block
+
+        /**
+         * get the key prefix used to identify the location of rune block
+         * 
+         * @return key prefix
+         */
+        protected abstract String getKeyPrefix();
+
+        /**
+         * check if itemStack has rune effect
+         * 
+         * @param stack The itemStack
+         * @return true if has effect, false otherwise
+         */
+        protected abstract boolean hasRuneApplied(@NotNull ItemStack stack);
+
+        /**
+         * return the itemStack that has rune effect
+         * 
+         * @param stack The itemStack be applied
+         * @param amount The amount of returned itemStack
+         * @return the itemStack
+         */
+        protected abstract ItemStack applyRune(@NotNull ItemStack stack, int amount);
+
+        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+        public void onBlockPlace(BlockPlaceEvent event) { // use chunk pdc
+            ItemStack itemStack = event.getItemInHand();
+            if (itemStack == null || itemStack.isEmpty()) {
+                return;
+            }
+
+            Block block = event.getBlock();
+            if (hasRuneApplied(itemStack)) {
+                block.getChunk().getPersistentDataContainer().set(
+                    getChunkPDC(RebarItem.isRebarItem(itemStack) ? getKeyPrefix() : RUNE_PREFIX, block.getLocation()),
+                    RebarSerializers.ITEM_STACK,
+                    itemStack.asOne()
+                );
+            }
+        }
+
+        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+        public void onBlockDropItem(@NotNull BlockDropItemEvent event) { //for vanilla block
+            Block block = event.getBlock();
+            NamespacedKey pdc = getChunkPDC(RUNE_PREFIX, block.getLocation());
+            
+            if (!block.getChunk().getPersistentDataContainer().has(pdc)) {
+                return;
+            }
+
+            ItemStack pdcItemStack = block.getChunk().getPersistentDataContainer()
+                    .get(pdc, RebarSerializers.ITEM_STACK);
+
+            if (pdcItemStack.hasData(DataComponentTypes.CONTAINER)) { //prevent the appearance of dupe
+                pdcItemStack.setData(DataComponentTypes.CONTAINER, ItemContainerContents.containerContents(new ArrayList<>()));
+            }
+
+            for (Item item : event.getItems()) {
+                ItemStack itemStack = item.getItemStack();
+                if (pdcItemStack.getType() != itemStack.getType()) {
+                    continue;
+                }
+
+                if (itemStack.hasData(DataComponentTypes.CONTAINER)) { //for vanilla shulkerbox
+                    pdcItemStack.setData(DataComponentTypes.CONTAINER, itemStack.getData(DataComponentTypes.CONTAINER));
+                }
+
+                itemStack.subtract();
+                block.getWorld().dropItemNaturally(block.getLocation(), pdcItemStack);
+
+                break;
+            }
+
+            block.getChunk().getPersistentDataContainer().remove(pdc);
+        }
+
+        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+        public void onRebarBlockBreak(@NotNull RebarBlockBreakEvent event) { // for rebar block
+            RebarBlock block = event.getRebarBlock();
+            NamespacedKey pdc = getChunkPDC(getKeyPrefix(), block.getBlock().getLocation());
+            if (!block.getBlock().getChunk().getPersistentDataContainer().has(pdc)) {
+                return;
+            }
+            for (ItemStack itemStack : event.getDrops()) {
+                RebarItemSchema dropSchema = RebarItemSchema.fromStack(itemStack);
+                if (dropSchema == null || !block.getKey().equals(dropSchema.getRebarBlockKey())) {
+                    continue;
+                }
+
+                ItemStack runeStack = applyRune(itemStack, 1);
+
+                itemStack.subtract();
+                event.getDrops().add(runeStack);
+
+                break;
+            }
+            block.getBlock().getChunk().getPersistentDataContainer().remove(pdc);
+        }
+
+        public NamespacedKey getChunkPDC(String prefix, Location location) { //record if block has rune effect
+            return PylonUtils.pylonKey(String.format("%s_%d_%d_%d",
+                prefix, location.getBlockX(), location.getBlockY(), location.getBlockZ()));
         }
     }
 }


### PR DESCRIPTION
Fixed a bug where RebarBlocks with Soulbound Rune and Fireproof Rune effects would lose both modifications upon being placed and subsequently broken by players.