### PR TITLE
Change grindstone clay block recipe to output 4 balls per block

### DIFF
--- a/src/main/resources/recipes/pylon/grindstone.yml
+++ b/src/main/resources/recipes/pylon/grindstone.yml
@@ -206,5 +206,5 @@ pylon:gravel_from_slag:
 pylon:clay_ball:
   input: minecraft:clay
   results:
-    minecraft:clay_ball: 3
+    minecraft:clay_ball: 4
   cycles: 1


### PR DESCRIPTION
Fixes #975 
This is to match the vanilla recipe