### PR TITLE
fix core drill throwing error

### DIFF
--- a/src/main/java/io/github/pylonmc/pylon/content/machines/simple/CoreDrill.java
+++ b/src/main/java/io/github/pylonmc/pylon/content/machines/simple/CoreDrill.java
@@ -146,7 +146,7 @@ public abstract class CoreDrill extends RebarBlock implements
                 PylonUtils.animate(getDrillDisplay(), rotationDuration / 4, getDrillDisplayMatrix(rotation));
                 if (spawnBlockParticles) {
                     Material type = getBlock().getRelative(BlockFace.DOWN, 3).getType();
-                    if (!type.isItem()) return;
+                    if (type.isAir() || !type.isItem()) return;
                     new ParticleBuilder(Particle.ITEM)
                             .count(5)
                             .extra(0.05)


### PR DESCRIPTION
Fixes #1010 
The issue is that Material.AIR.isItem() returns true because there is an Air ItemType but this is not a valid type for spawning particles. Fixed by adding an additional check to the block to make sure that the material is not air and has an item type