### PR TITLE
Register with Rebar before initializing metrics

### DIFF
--- a/src/main/java/io/github/pylonmc/pylon/Pylon.java
+++ b/src/main/java/io/github/pylonmc/pylon/Pylon.java
@@ -39,9 +39,12 @@ public class Pylon extends JavaPlugin implements RebarAddon {
     public void onEnable() {
         instance = this;
 
-        metrics = new Metrics(this, BSTATS_ID);
-
         registerWithRebar();
+
+        // Do not initialize plugin services until the required Rebar platform has
+        // successfully accepted this addon. This keeps a failed Rebar startup from
+        // leaving Pylon partially initialized.
+        metrics = new Metrics(this, BSTATS_ID);
 
         saveDefaultConfig();
 


### PR DESCRIPTION
Moves Pylon's Rebar registration before bStats initialization.

I ran into this while testing startup failures between Pylon and Rebar. If Rebar rejects the addon during startup, Pylon should not initialize additional plugin services first. 

This keeps Pylon from being partially initialized when registerWithRebar() fails.