### PR TITLE
Fix Rebar ref lookup in CI

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: 'pylonmc/rebar'
-          ref: ${{steps.rebarcommit.outputs.ref}} # empty string if ref not found falls back to master
+          ref: ${{steps.parseref.outputs.ref}} # empty string if ref not found falls back to master
           path: 'parallel-dev-repo/rebar'
 
       - name: Clone pylon


### PR DESCRIPTION
## Summary

- read the requested Rebar branch from the existing `parseref` step
- restore the `[ref:<branch>]` PR title behavior used for cross-repository changes

## Testing

- `git diff --check`
- verified that the workflow output reference matches the declared step ID

Fixes #1095