### PR TITLE
Clean up Paper 26.2 deprecations

### DIFF
--- a/src/main/java/io/github/pylonmc/pylon/content/science/Loupe.java
+++ b/src/main/java/io/github/pylonmc/pylon/content/science/Loupe.java
@@ -310,7 +310,7 @@ public final class Loupe extends RebarItem implements InteractRebarItemHandler, 
                     return;
                 }
 
-                hit.getWorld().playEffect(hit.getLocation(), Effect.STEP_SOUND, hit.getBlockData());
+                hit.getWorld().playEffect(hit.getLocation(), Effect.DESTROY_BLOCK, hit.getBlockData());
                 hit.setType(Material.AIR, true);
             } else {
                 // Prevents scanning the same instance of an unbreakable block again

--- a/src/main/java/io/github/pylonmc/pylon/util/DisplayProjectile.java
+++ b/src/main/java/io/github/pylonmc/pylon/util/DisplayProjectile.java
@@ -14,7 +14,6 @@ import org.bukkit.entity.Damageable;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.ItemDisplay;
 import org.bukkit.entity.Player;
-import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -104,17 +103,15 @@ public final class DisplayProjectile extends RebarEntity<ItemDisplay> implements
                 .map(Damageable.class::cast)
                 .findFirst();
         maybeHitEntity.ifPresent(hitEntity -> {
-            EntityDamageEvent event = new EntityDamageEvent(
-                    hitEntity,
-                    EntityDamageEvent.DamageCause.ENTITY_ATTACK,
+            var previousDamageEvent = hitEntity.getLastDamageCause();
+            hitEntity.damage(
+                    damage,
                     DamageSource.builder(DamageType.ARROW)
                             .withCausingEntity(player)
                             .withDirectEntity(hitEntity)
-                            .build(),
-                    damage
+                            .build()
             );
-            if (event.callEvent()) {
-                hitEntity.damage(damage, player);
+            if (hitEntity.getLastDamageCause() != previousDamageEvent) {
                 hitEntity.setVelocity(locationStep.clone().normalize().multiply(0.2));
                 if (hitSound != null) {
                     player.getWorld().playSound(hitSound, hitEntity);


### PR DESCRIPTION
Cleans up the remaining Paper 26.2 deprecation warnings from #1099.

* Replaces `Effect.STEP_SOUND` with `Effect.DESTROY_BLOCK` for the loupe break effect.
* Uses `Damageable#damage` instead of constructing `EntityDamageEvent` directly for display projectiles.
* Keeps knockback and hit sounds from firing when damage is cancelled.

And lastly the `LumberAxe` warning listed in the issue is already gone on current master.

Closes #1099
