### PR TITLE
Update Pylon for BlockStorage.getAs parameter order

### DIFF
--- a/src/main/java/io/github/pylonmc/pylon/content/building/Elevator.java
+++ b/src/main/java/io/github/pylonmc/pylon/content/building/Elevator.java
@@ -61,7 +61,7 @@ public class Elevator extends RebarBlock implements SneakRebarBlockHandler, Jump
         List<Elevator> elevators = new ArrayList<>();
         for (int i = 0; i < range; i++) {
             position.addScalar(0, under ? -1 : 1, 0);
-            Elevator elevator = BlockStorage.getAs(Elevator.class, position);
+            Elevator elevator = BlockStorage.getAs(position, Elevator.class);
             if (elevator != null) {
                 elevators.add(elevator);
             }

--- a/src/main/java/io/github/pylonmc/pylon/content/building/Immobilizer.java
+++ b/src/main/java/io/github/pylonmc/pylon/content/building/Immobilizer.java
@@ -106,7 +106,7 @@ public class Immobilizer extends RebarBlock implements PistonRebarBlockHandler, 
     private static void checkFrozenPlayers() {
         long now = Bukkit.getCurrentTick();
         for (Map.Entry<BlockPosition, Set<UUID>> entry: FROZEN_PLAYERS.entrySet()) {
-            Immobilizer immobilizer = BlockStorage.getAs(Immobilizer.class, entry.getKey());
+            Immobilizer immobilizer = BlockStorage.getAs(entry.getKey(), Immobilizer.class);
             if (immobilizer == null) {
                 continue;
             }

--- a/src/main/java/io/github/pylonmc/pylon/content/components/FluidHatch.java
+++ b/src/main/java/io/github/pylonmc/pylon/content/components/FluidHatch.java
@@ -74,7 +74,7 @@ public abstract class FluidHatch extends RebarBlock implements
     public boolean checkFormed() {
         boolean formed = SimpleRebarMultiblock.super.checkFormed();
         if (formed) {
-            FluidTankCasing casing = BlockStorage.getAs(FluidTankCasing.class, getBlock().getRelative(BlockFace.UP));
+            FluidTankCasing casing = BlockStorage.getAs(getBlock().getRelative(BlockFace.UP), FluidTankCasing.class);
             Preconditions.checkState(casing != null);
             Waila.addWailaOverride(casing.getBlock(), this);
             if (fluid != null) {
@@ -156,7 +156,7 @@ public abstract class FluidHatch extends RebarBlock implements
             createFluidBuffer(fluid, 0, true, true);
         }
         if (isFormedAndFullyLoaded() && fluid != null) {
-            FluidTankCasing casing = BlockStorage.getAs(FluidTankCasing.class, getBlock().getRelative(BlockFace.UP));
+            FluidTankCasing casing = BlockStorage.getAs(getBlock().getRelative(BlockFace.UP), FluidTankCasing.class);
             Preconditions.checkState(casing != null);
             setFluidCapacity(fluid, casing.capacity);
         }

--- a/src/main/java/io/github/pylonmc/pylon/content/machines/cargo/CargoInteractor.java
+++ b/src/main/java/io/github/pylonmc/pylon/content/machines/cargo/CargoInteractor.java
@@ -82,7 +82,7 @@ public abstract class CargoInteractor extends RebarBlock implements DirectionalR
 
         // Refresh list of target groups
         targetGroups.clear();
-        LogisticRebarBlock targetLogisticBlock = BlockStorage.getAs(LogisticRebarBlock.class, targetBlock);
+        LogisticRebarBlock targetLogisticBlock = BlockStorage.getAs(targetBlock, LogisticRebarBlock.class);
         if (targetLogisticBlock != null) {
             targetGroups.putAll(targetLogisticBlock.getLogisticGroups());
         } else {

--- a/src/main/java/io/github/pylonmc/pylon/content/machines/diesel/machines/DieselMixingAttachment.java
+++ b/src/main/java/io/github/pylonmc/pylon/content/machines/diesel/machines/DieselMixingAttachment.java
@@ -152,7 +152,7 @@ public class DieselMixingAttachment extends RebarBlock implements
             return;
         }
 
-        MixingPot mixingPot = BlockStorage.getAs(MixingPot.class, getBlock().getRelative(BlockFace.DOWN, 2));
+        MixingPot mixingPot = BlockStorage.getAs(getBlock().getRelative(BlockFace.DOWN, 2), MixingPot.class);
         if (mixingPot == null || !mixingPot.tryDoRecipe()) {
             return;
         }

--- a/src/main/java/io/github/pylonmc/pylon/content/machines/fluid/FluidTank.java
+++ b/src/main/java/io/github/pylonmc/pylon/content/machines/fluid/FluidTank.java
@@ -89,8 +89,8 @@ public class FluidTank extends RebarBlock
         casings.clear();
         for (int i = 0; i < maxHeight; i++) {
             FluidTankCasing casing = BlockStorage.getAs(
-                    FluidTankCasing.class,
-                    getBlock().getRelative(0, i + 1, 0)
+                    getBlock().getRelative(0, i + 1, 0),
+                    FluidTankCasing.class
             );
 
             FluidTankCasing casingType = casings.isEmpty() ? casing : casings.getFirst();

--- a/src/main/java/io/github/pylonmc/pylon/content/machines/hydraulics/HydraulicGrindstoneTurner.java
+++ b/src/main/java/io/github/pylonmc/pylon/content/machines/hydraulics/HydraulicGrindstoneTurner.java
@@ -71,7 +71,7 @@ public class HydraulicGrindstoneTurner extends RebarBlock implements
 
     @Override
     public void tick() {
-        Grindstone grindstone = BlockStorage.getAs(Grindstone.class, getBlock().getRelative(BlockFace.UP));
+        Grindstone grindstone = BlockStorage.getAs(getBlock().getRelative(BlockFace.UP), Grindstone.class);
         if (grindstone == null || grindstone.isProcessingRecipe() || !grindstone.isFormedAndFullyLoaded()) {
             return;
         }

--- a/src/main/java/io/github/pylonmc/pylon/content/machines/hydraulics/HydraulicMixingAttachment.java
+++ b/src/main/java/io/github/pylonmc/pylon/content/machines/hydraulics/HydraulicMixingAttachment.java
@@ -106,7 +106,7 @@ public class HydraulicMixingAttachment extends RebarBlock implements
             return;
         }
 
-        MixingPot mixingPot = BlockStorage.getAs(MixingPot.class, getBlock().getRelative(BlockFace.DOWN, 2));
+        MixingPot mixingPot = BlockStorage.getAs(getBlock().getRelative(BlockFace.DOWN, 2), MixingPot.class);
         if (mixingPot == null || fluidAmount(PylonFluids.HYDRAULIC_FLUID) < hydraulicFluidPerCraft
                 || fluidSpaceRemaining(PylonFluids.DIRTY_HYDRAULIC_FLUID) < hydraulicFluidPerCraft
                 || !mixingPot.tryDoRecipe()) {

--- a/src/main/java/io/github/pylonmc/pylon/content/machines/hydraulics/HydraulicPressPiston.java
+++ b/src/main/java/io/github/pylonmc/pylon/content/machines/hydraulics/HydraulicPressPiston.java
@@ -88,7 +88,7 @@ public class HydraulicPressPiston extends RebarBlock implements
 
     @Override
     public void tick() {
-        Press press = BlockStorage.getAs(Press.class, getBlock().getRelative(BlockFace.DOWN, 2));
+        Press press = BlockStorage.getAs(getBlock().getRelative(BlockFace.DOWN, 2), Press.class);
         if (press == null
                 || fluidAmount(PylonFluids.HYDRAULIC_FLUID) < hydraulicFluidPerCraft
                 || fluidSpaceRemaining(PylonFluids.DIRTY_HYDRAULIC_FLUID) < hydraulicFluidPerCraft

--- a/src/main/java/io/github/pylonmc/pylon/content/machines/simple/ManualCoreDrillLever.java
+++ b/src/main/java/io/github/pylonmc/pylon/content/machines/simple/ManualCoreDrillLever.java
@@ -44,8 +44,8 @@ public class ManualCoreDrillLever extends RebarBlock implements InteractRebarBlo
 
         Switch blockData = getBlockDataAs(Switch.class);
         ManualCoreDrill drill = BlockStorage.getAs(
-                ManualCoreDrill.class,
-                getBlock().getRelative(blockData.getFacing().getOppositeFace())
+                getBlock().getRelative(blockData.getFacing().getOppositeFace()),
+                ManualCoreDrill.class
         );
         if (drill == null || drill.isProcessing()) {
             event.setUseInteractedBlock(Event.Result.DENY);

--- a/src/main/java/io/github/pylonmc/pylon/content/machines/simple/PotionAltar.java
+++ b/src/main/java/io/github/pylonmc/pylon/content/machines/simple/PotionAltar.java
@@ -384,19 +384,19 @@ public class PotionAltar extends RebarBlock
     @Nullable
     private Pedestal getPotionPedestal1() {
         Vector3i offset = getBlockOffsets(POTION_PEDESTAL_COMPONENT).get(0);
-        return BlockStorage.getAs(Pedestal.class, getBlock().getRelative(offset.x(), offset.y(), offset.z()));
+        return BlockStorage.getAs(getBlock().getRelative(offset.x(), offset.y(), offset.z()), Pedestal.class);
     }
 
     @Nullable
     private Pedestal getPotionPedestal2() {
         Vector3i offset = getBlockOffsets(POTION_PEDESTAL_COMPONENT).get(1);
-        return BlockStorage.getAs(Pedestal.class, getBlock().getRelative(offset.x(), offset.y(), offset.z()));
+        return BlockStorage.getAs(getBlock().getRelative(offset.x(), offset.y(), offset.z()), Pedestal.class);
     }
 
     @Nullable
     private Pedestal getCatalystPedestal() {
         Vector3i offset = getBlockOffsets(SHIMMER_PEDESTAL_COMPONENT).getFirst();
-        return BlockStorage.getAs(Pedestal.class, getBlock().getRelative(offset.x(), offset.y(), offset.z()));
+        return BlockStorage.getAs(getBlock().getRelative(offset.x(), offset.y(), offset.z()), Pedestal.class);
     }
 
     @NotNull

--- a/src/main/java/io/github/pylonmc/pylon/content/machines/simple/ShimmerAltar.java
+++ b/src/main/java/io/github/pylonmc/pylon/content/machines/simple/ShimmerAltar.java
@@ -196,7 +196,7 @@ public class ShimmerAltar extends RebarBlock
         List<Pedestal> pedestals = new ArrayList<>();
         for (Vector3i vector : getComponents().keySet()) {
             Block block = getBlock().getRelative(vector.x, vector.y, vector.z);
-            pedestals.add(BlockStorage.getAs(Pedestal.class, block));
+            pedestals.add(BlockStorage.getAs(block, Pedestal.class));
         }
         return pedestals;
     }


### PR DESCRIPTION
Updates Pylon call sites for the BlockStorage.getAs(target, clazz) parameter order introduced in pylonmc/rebar#906

Validation:
- Rebar and Pylon both compiled successfully in parallel-dev-repo
- runServer reached successful Paper startup with both plugins enabled