### PR TITLE
fix: update crude alloy furnace lit state

### DIFF
--- a/src/main/java/io/github/pylonmc/pylon/content/machines/simple/CrudeAlloyFurnace.java
+++ b/src/main/java/io/github/pylonmc/pylon/content/machines/simple/CrudeAlloyFurnace.java
@@ -32,6 +32,7 @@ import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Particle;
 import org.bukkit.block.Block;
+import org.bukkit.block.data.type.Furnace;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.ItemType;
@@ -152,11 +153,13 @@ public class CrudeAlloyFurnace extends RebarBlock implements
                 tryConsumeFuel();
             }
             if (fuelTicksRemaining <= 0) {
+                editBlockDataAs(Furnace.class, furnace -> furnace.setLit(false));
                 return;
             }
         }
 
         fuelTicksRemaining -= getTickInterval();
+        editBlockDataAs(Furnace.class, furnace -> furnace.setLit(fuelTicksRemaining > 0));
         fuelProgressItem.setTotalTimeTicks(fuelTicksTotal);
         fuelProgressItem.setRemainingTimeTicks(fuelTicksRemaining);
         if (fuelTicksRemaining <= 0) {


### PR DESCRIPTION
## Issue

Fixes #1009

The Crude Alloy Furnace appeared unlit regardless of whether or not it was burning fuel.

## Summary

Updated the Crude Alloy Furnace so its block state correctly shows whether it currently has fuel. This makes the furnace appear lit while burning fuel and unlit when fuel runs out. 

## Testing

- Ran `./gradlew compileJava` successfully against the current Rebar.
- Tested the Crude Alloy Furnace in game.
- Before the change, the furnace processed recipes but never lit.
- After the change, the furnace now lights up while fuel is burning and turns off when fuel runs out.